### PR TITLE
Additional types of change options for PR

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,10 @@ Why are we doing this work? Link to relevant backlog items and/or describe the v
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Non-functional change (e.g. refactoring, performance improvements, reduction of technical debt etc)
 - [ ] Documentation
+- [ ] CI
+- [ ] Other - please specify
 
 # How Has This Been Tested?
 


### PR DESCRIPTION
# Description

Adds a few types of change reason that were not really covered by the initial set. In addition to the one mentioned on slack (example PR here https://github.com/Parkopedia/hdmaps-datacapture/pull/136), I also added a `CI` option (example PR here https://github.com/Parkopedia/hdmaps-pointclouds/pull/360), plus a catch all `Other - please specify`.
With the expectation that if `Other` was used frequently for the same reason, that would also get added to the template.
