### PR TITLE
Replace checkboxes with bullet point lists

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,14 +7,15 @@ Please include a summary of the change, including relevant context, and detail a
 Why are we doing this work? Link to relevant backlog items and/or describe the value of the change.
 
 ## Type of change
+*Delete as appropriate*
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Non-functional change (e.g. refactoring, performance improvements, reduction of technical debt etc)
-- [ ] Documentation
-- [ ] CI
-- [ ] Other - please specify
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- Non-functional change (e.g. refactoring, performance improvements, reduction of technical debt etc)
+- Documentation
+- CI
+- Other - please specify
 
 # How Has This Been Tested?
 
@@ -23,9 +24,10 @@ Were tests added to cover these changes?
 Are all of the CI checks passing?
 
 # Checklist
+*Delete as appropriate*
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing tests pass with my changes
+- My code follows the style guidelines of this project
+- I have commented my code, particularly in hard-to-understand areas
+- I have made corresponding changes to the documentation
+- I have added tests that prove my fix is effective or that my feature works
+- New and existing tests pass with my changes


### PR DESCRIPTION
# Description

Replaces checkboxes with bullet point lists.

# Motivation

As discussed, allows the github tasks feature to still be used.

## Type of change
- Other - Change to Markdown template

# How Has This Been Tested?

Markdown validated in the Github UI

# Checklist
n/a
